### PR TITLE
Fix link to code in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tested against Python 3.9, 3.10 and 3.11.
 ## Installation
 
 No need to install anything else! If you've got Python 3.9+ on your system, then just clone the repo
-(or copy the content of [py_of_life.py]([./py_of_life.py]) over to a local file).
+(or copy the content of [py_of_life.py](./py_of_life.py) over to a local file).
 
 ## Usage
 


### PR DESCRIPTION
Current link to `py_of_life.py` in README file isn't working